### PR TITLE
Added the ability to open client IT Glue documentation

### DIFF
--- a/IT Glue Client IDs_JAN2024.json
+++ b/IT Glue Client IDs_JAN2024.json
@@ -1,0 +1,1446 @@
+{
+    "119 W Wayne St Garage": {
+        "119 W Wayne St Garage": "7681633"
+    },
+    "1st Source Bank": {
+        "1st Source Bank": "7118288"
+    },
+    "20 Fulton Street East LLC": {
+        "20 Fulton Street East LLC": "7126599"
+    },
+    "3Rivers Federal Credit Union": {
+        "3Rivers Federal Credit Union": "7118314"
+    },
+    "705 Design": {
+        "705 Design": "7118453"
+    },
+    "ABI Attachments": {
+        "ABI Attachments": "7118494"
+    },
+    "Abraxas Worldwide": {
+        "Abraxas Worldwide": "7118877"
+    },
+    "Absolute Rehabilitation": {
+        "Absolute Rehabilitation": "1449288"
+    },
+    "AC3, Inc": {
+        "AC3, Inc.": "7118363"
+    },
+    "ACI Parts Warehousing": {
+        "ACI Parts Warehousing": "7118884"
+    },
+    "Ada Township": {
+        "Ada Township": "7681741"
+    },
+    "Adams Remco, Inc": {
+        "Adams Remco, Inc.": "7118226"
+    },
+    "Addison Community Schools": {
+        "Addison Community Schools": "7118889"
+    },
+    "Adsorption Research, Inc": {
+        "Adsorption Research, Inc.": "3784711"
+    },
+    "Adventist Frontier Missions": {
+        "Adventist Frontier Missions": "7118384"
+    },
+    "AE Tech Design": {
+        "AE Tech Design": "7681742"
+    },
+    "AGC Flat Glass North America": {
+        "AGC Flat Glass North America": "1449156"
+    },
+    "AGC Glass Company NA": {
+        "AGC Glass Company NA": "1449278"
+    },
+    "Air Power America": {
+        "Air Power America": "7681743"
+    },
+    "Air-Way Manufacturing Company": {
+        "Air-Way Manufacturing Company": "7118902"
+    },
+    "Akzo Nobel Coatings, Inc": {
+        "Akzo Nobel Coatings, Inc.": "7118904"
+    },
+    "Aldridge Insurance, Inc": {
+        "Aldridge Insurance, Inc.": "7118496"
+    },
+    "Allegan Public Schools": {
+        "Allegan Public Schools": "7118912"
+    },
+    "Alliance RV, Inc": {
+        "Alliance RV, Inc.": "7126864"
+    },
+    "Allied Physicians of Michiana": {
+        "Allied Physicians of Michiana": "7118498"
+    },
+    "Aluminum Trailer Co": {
+        "Aluminum Trailer Co.": "7681634"
+    },
+    "AM General LLC": {
+        "AM General LLC": "7118312"
+    },
+    "American Health Holdings, Inc": {
+        "American Health Holdings, Inc": "1449216"
+    },
+    "AmeriFirst Financial Corporation": {
+        "AmeriFirst Financial Corporation": "7681745"
+    },
+    "Andrews University": {
+        "Andrews University": "7118936"
+    },
+    "Antwerp Township": {
+        "Antwerp Township": "7681746"
+    },
+    "Aon Service Corporation": {
+        "Aon Service Corporation": "7126969"
+    },
+    "Apollo Precision Machining": {
+        "Apollo Precision Machining": "7681636"
+    },
+    "Applied Electric": {
+        "Applied Electric": "7202181"
+    },
+    "Aranowski & Company CPAs": {
+        "Aranowski & Company CPAs": "7118447"
+    },
+    "Arbor Financial Credit Union": {
+        "Arbor Financial Credit Union": "7681747"
+    },
+    "ARCH Medical Solutions": {
+        "ARCH Medical Solutions": "7681597"
+    },
+    "Armstrong Cable": {
+        "Armstrong Cable": "7161428"
+    },
+    "Arts Council of Greater Kalamazoo": {
+        "Arts Council of Greater Kalamazoo": "7681749"
+    },
+    "Ascend Consulting LLC": {
+        "Ascend Consulting LLC": "1504969"
+    },
+    "Athens Dental Arts": {
+        "Athens Dental Arts": "7127014"
+    },
+    "Aunalytics": {
+        "Aunalytics": "1449031",
+        "Aunalytics, Inc.": "7118225",
+        "Aunalytics, Inc. - Multi-Tenant": "7164590"
+    },
+    "AZO Services Management, Inc": {
+        "AZO Services Management, Inc.": "7118960"
+    },
+    "B&L Information": {
+        "B&L Information Systems": "7118963"
+    },
+    "C2AE": {
+        "C2AE": "7119059"
+    },
+    "C2Dx": {
+        "C2Dx": "7119664"
+    },
+    "Cafe Navarre": {
+        "Cafe Navarre": "7681644"
+    },
+    "Caledonia Community Schools": {
+        "Caledonia Community Schools": "7119062"
+    },
+    "Calhoun County": {
+        "Calhoun County, MI": "7119065"
+    },
+    "Calhoun ISD": {
+        "Calhoun ISD": "7119066"
+    },
+    "Calvin Christian Reformed Church": {
+        "Calvin Christian Reformed Church": "7119067"
+    },
+    "Camp Madron": {
+        "Camp Madron": "7118532"
+    },
+    "Cardinal Appraisals": {
+        "Cardinal Appraisals": "1449244"
+    },
+    "CARES - Community AIDS Resource & Edu Svcs": {
+        "CARES - Community AIDS Resource & Edu Svcs": "7681755"
+    },
+    "Carroll Electric Cooperative, Inc": {
+        "Carroll Electric Cooperative, Inc.": "7161436"
+    },
+    "Cassopolis Public Schools": {
+        "Cassopolis Public Schools": "7126652"
+    },
+    "Cast Coatings, Inc": {
+        "Cast Coatings, Inc.": "7681756"
+    },
+    "Cedar Glen Apartment Homes": {
+        "Cedar Glen Apartment Homes": "7681647"
+    },
+    "Centennial Mortgage, Inc": {
+        "Centennial Mortgage, Inc.": "7118537"
+    },
+    "Center for Hospice Care": {
+        "Center for Hospice Care": "7118365"
+    },
+    "Center for Positive Change": {
+        "Center for Positive Change": "7681649"
+    },
+    "Central Ohio Youth Center": {
+        "Central Ohio Youth Center": "3784704"
+    },
+    "Central Plains Center": {
+        "Central Plains Center": "7126660"
+    },
+    "Chemical Abstracts Service": {
+        "Chemical Abstracts Service": "1449272"
+    },
+    "CHI Networks": {
+        "CHI Networks": "7161415"
+    },
+    "ChoiceLight, Inc": {
+        "ChoiceLight, Inc.": "7681712"
+    },
+    "Christ the King School": {
+        "Christ the King School": "7118440"
+    },
+    "CIC Plus, Inc": {
+        "CIC Plus, Inc.": "7681582"
+    },
+    "Citizens Federal Savings & Loan": {
+        "Citizens Federal Savings & Loan": "7161439"
+    },
+    "City of Benton Harbor": {
+        "City of Benton Harbor, MI": "7119254"
+    },
+    "City of Elkhart": {
+        "City of Elkhart, IN": "7681595"
+    },
+    "City of Hastings": {
+        "City of Hastings, MI": "7119274"
+    },
+    "City of Kalamazoo": {
+        "City of Kalamazoo, MI": "7119278"
+    },
+    "City of Mishawaka": {
+        "City of Mishawaka, IN": "7118371"
+    },
+    "City of Muncie": {
+        "City of Muncie, IN": "7118433"
+    },
+    "City of Plymouth": {
+        "City of Plymouth, IN": "7118544"
+    },
+    "City of Portage": {
+        "City of Portage, MI": "7119296"
+    },
+    "City of Rochester": {
+        "City of Rochester, IN": "7119302"
+    },
+    "City of South Bend": {
+        "City of South Bend, IN": "7118326"
+    },
+    "City of South Haven": {
+        "City of South Haven, MI": "7119309"
+    },
+    "City of Wyoming": {
+        "City of Wyoming, MI": "7681761"
+    },
+    "Classic Windows & Doors-N-More": {
+        "Classic Windows & Doors-N-More": "1449245"
+    },
+    "Cogent Communications": {
+        "Cogent Communications": "7370215"
+    },
+    "Coker Tire": {
+        "Coker Tire": "7547995"
+    },
+    "Com Control Inc": {
+        "Com Control Inc.": "7681651"
+    },
+    "Comcast": {
+        "Comcast": "7370216",
+        "Comcast (MHO)": "7370313",
+        "Comcast - 2247 SB Lead": "7370218",
+        "Comcast - 2813 Secant": "7370219",
+        "Comcast - 6043 AU SB": "7370226",
+        "Comcast - 6242 AU Cld": "7370227",
+        "Comcast - 6728 Van Buren C MH": "7370228",
+        "Comcast - 7049 Siegfried Crandall": "7370229",
+        "Comcast - 8327 Trinity LS": "7370233",
+        "Comcast - 8457 Berrien MH": "7370234",
+        "Comcast - 9250 SB ISP": "7370235",
+        "Comcast - 9423 AkzoNobel": "7370236",
+        "Comcast Business": "7370237",
+        "Comcast Cable Corporation": "7118551",
+        "Comcast National Business": "7370127"
+    },
+    "Comfort Xpress": {
+        "Comfort Xpress": "7681850"
+    },
+    "Commodore Homes": {
+        "Commodore Homes, LLC": "7118380"
+    },
+    "Communication Company of South Bend Inc": {
+        "Communication Company of South Bend Inc.": "7681612"
+    },
+    "Communication Federal Credit Union": {
+        "Communication Federal Credit Union": "7161425"
+    },
+    "Communities in Schools of Kalamazoo": {
+        "Communities in Schools of Kalamazoo": "7119434"
+    },
+    "Concraft Inc": {
+        "Concraft Inc.": "7119484"
+    },
+    "Consolidated Electric Cooperative, Inc": {
+        "Consolidated Electric Cooperative, Inc.": "1449128"
+    },
+    "Consultant Connect": {
+        "Consultant Connect": "7119521"
+    },
+    "Corvette Central (dba of CC Industries)": {
+        "Corvette Central (dba of CC Industries)": "7119591"
+    },
+    "Coughlin Automotive London": {
+        "Coughlin Automotive London": "3795125"
+    },
+    "Courtland Title & Escrow, Inc": {
+        "Courtland Title & Escrow, Inc.": "7118419"
+    },
+    "Coxline, Inc": {
+        "Coxline, Inc.": "7681833"
+    },
+    "Craft Paper Scissors": {
+        "Craft Paper Scissors": "7681851"
+    },
+    "Cressy Commercial Real Estate": {
+        "Cressy Commercial Real Estate": "7665918"
+    },
+    "CSE Morse, Inc": {
+        "CSE Morse, Inc.": "7119677"
+    },
+    "CTS": {
+        "Climax Telephone Company (CTS)": "7370125"
+    },
+    "Customer Retention Solutions, Inc": {
+        "Customer Retention Solutions, Inc": "7119723"
+    },
+    "Cutler Funeral Home and Cremation Center": {
+        "Cutler Funeral Home and Cremation Center": "7681654"
+    },
+    "CWS Financial Advisors LLC": {
+        "CWS Financial Advisors LLC": "7119730"
+    },
+    "Cyprus Federal Credit Union": {
+        "Cyprus Federal Credit Union": "7292549"
+    },
+    "Daido Metal USA Inc": {
+        "Daido Metal USA Inc.": "1449178"
+    },
+    "Datacruz": {
+        "Datacruz Internet, Inc.": "7118324"
+    },
+    "Decker Construction Co": {
+        "Decker Construction Co.": "3728563"
+    },
+    "DeNooyer Chevrolet": {
+        "DeNooyer Chevrolet": "7119866"
+    },
+    "Dewald Fluid Power": {
+        "Dewald Fluid Power": "7118345"
+    },
+    "Dicastal": {
+        "Dicastal": "7119898"
+    },
+    "Dickman Supply, Inc": {
+        "Dickman Supply, Inc.": "7681852"
+    },
+    "Diocese of Kalamazoo": {
+        "Diocese of Kalamazoo": "7681767"
+    },
+    "DLZ Corporation": {
+        "DLZ Corporation": "7681853"
+    },
+    "Dodds Wealth Advisors": {
+        "Dodds Wealth Advisors": "1449109"
+    },
+    "Donnell Systems, Inc": {
+        "Donnell Systems, Inc.": "7118313"
+    },
+    "DSW Shoe Warehouse": {
+        "DSW Shoe Warehouse": "1449275"
+    },
+    "Dwyer": {
+        "Dwyer Instruments, Inc.": "7681655"
+    },
+    "East Grand Rapids Public Schools": {
+        "East Grand Rapids Public Schools": "7120056"
+    },
+    "Easton Water Solutions": {
+        "Easton Water Solutions": "1449246"
+    },
+    "Edwards Garment Co": {
+        "Edwards Garment Co.": "7120165"
+    },
+    "EMI": {
+        "EMI": "7127096"
+    },
+    "Endodontic Services": {
+        "Endodontic Services": "7118393"
+    },
+    "Engel Inc": {
+        "Engel Inc.": "7161504"
+    },
+    "Enzyme Research, Inc": {
+        "Enzyme Research, Inc.": "7118306"
+    },
+    "Epoch Architecture + Planning": {
+        "Epoch Architecture + Planning": "7681658"
+    },
+    "Excel Electronics, Inc": {
+        "Excel Electronics, Inc.": "7118328"
+    },
+    "Express Press Production, Inc": {
+        "Express Press Production, Inc.": "7681661"
+    },
+    "Express Press Systems, Inc": {
+        "Express Press Systems, Inc.": "7681614"
+    },
+    "Families First Center": {
+        "Families First Center": "7681662"
+    },
+    "Family & Children Services": {
+        "Family & Children Services (Kalamazoo)": "7681770"
+    },
+    "Family & Children's Center Inc": {
+        "Family & Children's Center Inc.": "7665920"
+    },
+    "Farm Journal Media": {
+        "Farm Journal Media": "7118580"
+    },
+    "Farmers State Bank": {
+        "Farmers State Bank": "7118308"
+    },
+    "Fastco Industries Inc": {
+        "Fastco Industries Inc.": "7681772"
+    },
+    "FEMA Corporation": {
+        "FEMA Corporation": "7120361"
+    },
+    "Festida Foods": {
+        "Festida Foods": "7120374"
+    },
+    "Five Star Sheets": {
+        "Five Star Sheets": "7118582"
+    },
+    "Flowserve FSD Corporation": {
+        "Flowserve FSD Corporation": "7120426"
+    },
+    "Folk Oil Company, Inc": {
+        "Folk Oil Company, Inc": "7120468"
+    },
+    "Fort Wayne Community Schools": {
+        "Fort Wayne Community Schools": "7681604"
+    },
+    "Four Winds Casino": {
+        "Four Winds Casino": "7120497"
+    },
+    "Fullbeauty Brands, Inc": {
+        "Fullbeauty Brands, Inc.": "7118416"
+    },
+    "Galilee Baptist Church": {
+        "Galilee Baptist Church": "7681776"
+    },
+    "Garden Court West": {
+        "Garden Court West": "7118587"
+    },
+    "Genesis Products": {
+        "Genesis Products": "7118406"
+    },
+    "Gibson": {
+        "Gibson": "7665915"
+    },
+    "Goken America": {
+        "Goken America": "7127136"
+    },
+    "Goodwill Industries of West Michigan": {
+        "Goodwill Industries of West Michigan": "7120720"
+    },
+    "Goshen Health System, Inc": {
+        "Goshen Health System, Inc.": "7118389"
+    },
+    "Graham Allen Partners": {
+        "Graham Allen Partners": "7118352"
+    },
+    "Great Lakes Capital Partners": {
+        "Great Lakes Capital Partners": "7118464"
+    },
+    "Great Lakes Forest Products Inc": {
+        "Great Lakes Forest Products Inc.": "7118598"
+    },
+    "Great Lakes Lamination": {
+        "Great Lakes Lamination": "7118864"
+    },
+    "Green Hills Community": {
+        "Green Hills Community": "7127143"
+    },
+    "Green Meadows Paper Company": {
+        "Green Meadows Paper Company": "7161477"
+    },
+    "Green Stream Company": {
+        "Green Stream Company": "7118374"
+    },
+    "GreenMark Equipment, Inc": {
+        "GreenMark Equipment, Inc.": "7118599"
+    },
+    "Greenville Public Schools": {
+        "Greenville Public Schools": "7681779"
+    },
+    "Group Delphi, Inc": {
+        "Group Delphi, Inc.": "7681606"
+    },
+    "Gulf Coast Center": {
+        "Gulf Coast Center": "7126718"
+    },
+    "H&R Wood Specialties": {
+		"H&R Wood Specialties": "7120867"
+    },
+    "Hackett & Associates, PC": {
+        "Hackett & Associates, PC": "7681671"
+    },
+    "Hanson Mold": {
+        "Hanson Mold": "7120930"
+    },
+    "Harmony Healthcare IT": {
+        "Harmony Healthcare IT": "7118404"
+    },
+    "Hebard & Hebard Architects, Inc": {
+        "Hebard & Hebard Architects, Inc.": "7681616"
+    },
+    "Heco Incorporated": {
+        "Heco Incorporated": "7120989"
+    },
+    "Helen Farabee Centers": {
+        "Helen Farabee Centers": "7126725"
+    },
+    "Heritage Financial Group": {
+        "Heritage Financial Group": "7126889"
+    },
+    "HH Cassopolis LLC": {
+        "HH Cassopolis LLC": "7126989"
+    },
+    "Hiler Industries, Inc": {
+        "Hiler Industries, Inc.": "7437272"
+    },
+    "Hilltop Wealth Solutions": {
+        "Hilltop Wealth Solutions": "7118614"
+    },
+    "Hinman Company": {
+        "Hinman Company": "7121095"
+    },
+    "Hoekstra Roofing Company": {
+        "Hoekstra Roofing Company": "7121121"
+    },
+    "Holladay Properties": {
+        "Holladay Properties": "7681673"
+    },
+    "Holy Cross Village": {
+        "Holy Cross Village": "7118446"
+    },
+    "Honor Credit Union": {
+        "Honor Credit Union": "7681782"
+    },
+    "Hoogstraten Builders": {
+        "Hoogstraten Builders": "7121165"
+    },
+    "Hoosier Racing Tire": {
+        "Hoosier Racing Tire": "7118337"
+    },
+    "Horizon Bank Corporation": {
+        "Horizon Bank Corporation": "7118373"
+    },
+    "Horizon Global Company LLC": {
+        "Horizon Global Company LLC": "7118353"
+    },
+    "House of Flavors": {
+        "House of Flavors": "7681783"
+    },
+    "Housing Authority of South Bend": {
+        "Housing Authority of South Bend": "7665917"
+    },
+    "HR of Indiana LLC": {
+        "HR of Indiana LLC": "7681674"
+    },
+    "HRR Enterprises, Inc": {
+        "HRR Enterprises, Inc.": "7681576"
+    },
+    "HS Fleet Services LLC": {
+        "HS Fleet Services LLC": "7121197"
+    },
+    "Hubbard Hill Retirement Community": {
+        "Hubbard Hill Retirement Community": "7681733"
+    },
+    "HyTech Spring & Machine (Tokusen HyTech)": {
+        "HyTech Spring & Machine (Tokusen HyTech)": "7121234"
+    },
+    "Imagineering Finishing Technologies": {
+        "Imagineering Finishing Technologies": "7118258"
+    },
+    "Imperial Beverage": {
+        "Imperial Beverage": "7121241"
+    },
+    "Incedo LLC": {
+        "Incedo LLC": "7681739"
+    },
+    "Indiana Trust Wealth Management": {
+        "Indiana Trust Wealth Management": "7118626"
+    },
+    "Industrial Quick Search, Inc": {
+        "Industrial Quick Search, Inc.": "7121245"
+    },
+    "Innovia Consulting": {
+        "Innovia Consulting": "7118629"
+    },
+    "Inova Federal Credit Union": {
+        "INOVA Federal Credit Union": "7121248"
+    },
+    "InPower LLC": {
+        "InPower LLC": "7681859"
+    },
+    "Integrated Services of Kalamazoo": {
+        "Integrated Services of Kalamazoo": "7126859"
+    },
+    "Intelliplex, Inc": {
+        "Intelliplex, Inc.": "7118350"
+    },
+    "InterCambio Express, Inc": {
+        "InterCambio Express, Inc.": "7161406"
+    },
+    "Interlink Companies": {
+        "Interlink Companies": "7118273"
+    },
+    "International Radio & Electronics": {
+        "International Radio & Electronics": "7118235"
+    },
+    "Interra Credit Union": {
+        "Interra Credit Union": "7118342"
+    },
+    "Investment Property Services": {
+        "Investment Property Services": "7118634"
+    },
+    "Investors Title Service, Inc": {
+        "Investors Title Service, Inc.": "7118425"
+    },
+    "IU Health LaPorte Hospital": {
+        "IU Health LaPorte Hospital": "7118286"
+    },
+    "Ivy Court": {
+        "Ivy Court": "7681680"
+    },
+    "Jae's Sandwich Shop - TEST ACCOUNT": {
+        "Jae's Sandwich Shop - TEST ACCOUNT": "7121471"
+    },
+    "Jae's Subsidiary - TEST ACCOUNT": {
+        "Jae's Subsidiary - TEST ACCOUNT": "7161484"
+    },
+    "Jay's Sporting Goods": {
+        "Jay's Sporting Goods": "7121510"
+    },
+    "Jefferson Centre Associates": {
+        "Jefferson Centre Associates": "7118639"
+    },
+    "Johnson-Rauhoff": {
+        "Johnson-Rauhoff": "7121556"
+    },
+    "K&M Machine-Fabricating, Inc": {
+		"K&M Machine-Fabricating, Inc.": "7118863"
+    },
+    "K2 Industrial Services": {
+        "K2 Industrial Services": "7681573"
+    },
+    "Kalamazoo Anesthesiology PC": {
+        "Kalamazoo Anesthesiology PC": "7681786"
+    },
+    "Kalamazoo Christian School Asc": {
+        "Kalamazoo Christian School Asc": "7121650"
+    },
+    "Kalamazoo Civic Theatre": {
+        "Kalamazoo Civic Theatre": "7121657"
+    },
+    "Kalamazoo College": {
+        "Kalamazoo College": "7121664"
+    },
+    "Kalamazoo Department of Public Safety": {
+        "Kalamazoo Department of Public Safety": "7121726"
+    },
+    "Kalamazoo Landscape Supplies": {
+        "Kalamazoo Landscape Supplies": "7121763"
+    },
+    "Kalamazoo Loaves & Fishes": {
+        "Kalamazoo Loaves & Fishes": "7681789"
+    },
+    "Kalamazoo Promise": {
+        "Kalamazoo Promise": "7119433"
+    },
+    "Kalamazoo Public Library": {
+        "Kalamazoo Public Library": "7681790"
+    },
+    "Kalamazoo Public Schools": {
+        "Kalamazoo Public Schools": "7121817"
+    },
+    "Kalamazoo State Theatre": {
+        "Kalamazoo State Theatre": "7121824"
+    },
+    "Kalexsyn, Inc": {
+        "Kalexsyn, Inc.": "7121836"
+    },
+    "Kalsec Inc": {
+        "Kalsec Inc.": "7681791"
+    },
+    "Kalsee Credit Union": {
+        "Kalsee Credit Union": "7121842"
+    },
+    "Kellogg Community College": {
+        "Kellogg Community College": "7121848"
+    },
+    "Kentwood Public Schools": {
+        "Kentwood Public Schools": "7121868"
+    },
+    "Kinetic IT Solutions": {
+        "Kinetic IT Solutions": "7681579"
+    },
+    "Kirkland & Ellis LLP": {
+        "Kirkland & Ellis LLP": "7118340"
+    },
+    "Koontz Wagner": {
+        "Koontz Wagner": "7118652"
+    },
+    "Kotys Wealth Professionals": {
+        "Kotys Wealth Professionals": "7681686"
+    },
+    "Laaksonen Law Offices PC": {
+        "Laaksonen Law Offices PC": "7681796"
+    },
+    "Lake City Bank": {
+        "Lake City Bank": "7161429"
+    },
+    "Lawrence Freezer Corporation": {
+        "Lawrence Freezer Corporation": "7681797"
+    },
+    "Legacy Energy Company": {
+        "Legacy Energy Company": "7122199"
+    },
+    "Level 3": {
+        "Level 3 Communications": "7161418"
+    },
+    "Level Data": {
+        "Level Data": "7122237"
+    },
+    "Lincoln Manufacturing, Inc": {
+        "Lincoln Manufacturing, Inc.": "7681798"
+    },
+    "Lineage Logistics": {
+        "Lineage Logistics LLC": "7120924"
+    },
+    "Lippert Components, Inc": {
+        "Lippert Components, Inc.": "7118292"
+    },
+    "Liquid Packaging Solutions": {
+        "Liquid Packaging Solutions": "7681619"
+    },
+    "Lochmueller Group": {
+        "Lochmueller Group": "7118668"
+    },
+    "Logan Acres Nursing Home": {
+        "Logan Acres Nursing Home": "7161444"
+    },
+    "Logan Community Resources, Inc": {
+        "Logan Community Resources, Inc. (Logan Center)": "7681689"
+    },
+    "Longstreet Elder Law & Estate Planning PC": {
+        "Longstreet Elder Law & Estate Planning PC": "7122320"
+    },
+    "Lorain-Medina Rural Electric Cooperative, Inc": {
+        "Lorain-Medina Rural Electric Cooperative, Inc": "1449127"
+    },
+    "Low Associates": {
+        "Low Associates": "7118367"
+    },
+    "Macomb Intermediate School District": {
+        "Macomb Intermediate School District": "7122374"
+    },
+    "Mad River Knife": {
+        "Mad River Knife": "1449255"
+    },
+    "Magen David Yeshivah High School": {
+        "Magen David Yeshivah High School": "7681800"
+    },
+    "Manufacturing Technology, Inc": {
+        "Manufacturing Technology, Inc.": "7681578"
+    },
+    "Maplenet": {
+        "Maplenet Wireless Inc. (Surf Broadband)": "7118364"
+    },
+    "Marker Inc": {
+        "Marker Inc.": "1449067"
+    },
+    "Martin's Super Markets": {
+        "Martin's Super Markets": "7118329"
+    },
+    "Mary Rutan Hospital": {
+        "Mary Rutan Hospital": "1449058"
+    },
+    "Mattawan Consolidated Schools": {
+        "Mattawan Consolidated Schools": "7122455"
+    },
+    "May Oberfell Lorber": {
+        "May Oberfell Lorber": "7118443"
+    },
+    "Meal Magic Corporation": {
+        "Meal Magic Corporation": "7122462"
+    },
+    "Medallion Management, Inc": {
+        "Medallion Management, Inc.": "7122476"
+    },
+    "Melek": {
+        "Melek, Inc.": "7161419"
+    },
+    "Meridian Title Corporation": {
+        "Meridian Title Corporation": "7118238"
+    },
+    "Metal Spinners, Inc": {
+        "Metal Spinners, Inc.": "7118358"
+    },
+    "MHDAS of Logan and Champaign Counties": {
+        "MHDAS of Logan and Champaign Counties": "7681861"
+    },
+    "MichaelAngelos Events": {
+        "MichaelAngelos Events": "7681693"
+    },
+    "Michiana Health Information Network": {
+        "Michiana Health Information Network": "7681621"
+    },
+    "Michiana Hematology Oncology": {
+        "Michiana Hematology Oncology": "7118309"
+    },
+    "Mid-States Packaging, Inc": {
+        "Mid-States Packaging, Inc.": "3015939"
+    },
+    "Midco": {
+        "Midco": "7161426"
+    },
+    "Midwest Electric, Inc": {
+        "Midwest Electric, Inc.": "1449126"
+    },
+    "Miller Energy Company": {
+        "Miller Energy Company": "7681804"
+    },
+    "Miller Poultry": {
+        "Miller Poultry": "7118862"
+    },
+    "Moline Christian School": {
+        "Moline Christian School": "7681805"
+    },
+    "Monnier & Co": {
+        "Monnier & Co.": "1449087"
+    },
+    "Moore Electrical Service, Inc": {
+        "Moore Electrical Service, Inc": "7122790"
+    },
+    "Mossberg": {
+        "Mossberg & Company, Inc.": "7118698"
+    },
+    "Motan Inc": {
+        "Motan Inc.": "7122829"
+    },
+    "National Extrusion": {
+        "National Extrusion": "7681863"
+    },
+    "Nature's Way Landscaping, Inc": {
+        "Nature's Way Landscaping, Inc": "7681807"
+    },
+    "ND Stadium Club": {
+        "ND Stadium Club": "7681698"
+    },
+    "Nephrology Physicians LLC": {
+        "Nephrology Physicians LLC": "7681701"
+    },
+    "Neuropsychiatric Hospitals Corporate Offices": {
+        "Neuropsychiatric Hospitals Corporate Offices": "7118705"
+    },
+    "Neuropsychiatric Hospitals of Indianapolis": {
+        "Neuropsychiatric Hospitals of Indianapolis": "7118706"
+    },
+    "New Carbon Company": {
+        "New Carbon Company": "7118709"
+    },
+    "New Creation Fellowship": {
+        "New Creation Fellowship": "7681702"
+    },
+    "New York Blower": {
+        "New York Blower": "7681583"
+    },
+    "Newaygo Public School District": {
+        "Newaygo Public School District": "7122943"
+    },
+    "NIBCO": {
+        "NIBCO, Inc.": "7161399"
+    },
+    "NORRES North America Inc": {
+        "NORRES North America Inc.": "7681703"
+    },
+    "North Judson-San Pierre School Corp": {
+        "North Judson-San Pierre School Corp.": "7118299"
+    },
+    "Northern IN Manufacturing": {
+        "Northern IN Manufacturing": "7118715"
+    },
+    "Northwestern Michigan College": {
+        "Northwestern Michigan College": "7123045"
+    },
+    "Northwood Group LLC": {
+        "Northwood Group LLC": "7681808"
+    },
+    "Notre Dame Federal Credit Union": {
+        "Notre Dame Federal Credit Union": "7118289"
+    },
+    "Nulty Insurance": {
+        "Nulty Insurance": "7123057"
+    },
+    "NX Automotive Logistics USA, Inc": {
+        "NX Automotive Logistics USA, Inc.": "7161459"
+    },
+    "Oaklawn Psychiatric Center Inc": {
+        "Oaklawn Psychiatric Center Inc.": "7123089"
+    },
+    "Office Interiors, Inc": {
+        "Office Interiors, Inc.": "7681705"
+    },
+    "Old National Bank": {
+        "Old National Bank": "7118399"
+    },
+    "OrthoPediatrics": {
+        "OrthoPediatrics": "7118405"
+    },
+    "Orthos, Inc": {
+        "Orthos, Inc.": "7126927"
+    },
+    "Oshtemo Charter Township": {
+        "Oshtemo Charter Township": "7123178"
+    },
+    "OSMC": {
+        "OSMC": "7118274"
+    },
+    "Patrick Industries, Inc": {
+        "Patrick Industries, Inc.": "7118307"
+    },
+    "Paulding Putnam Electric Cooperative, Inc": {
+        "Paulding Putnam Electric Cooperative, Inc.": "7127027"
+    },
+    "Paw Paw Township": {
+        "Paw Paw Township": "7681812"
+    },
+    "Pecan Valley Centers for Behavioral and Developmental Healthcare": {
+        "Pecan Valley Centers for Behavioral and Developmental Healthcare": "7126805"
+    },
+    "Peerless-Midwest, Inc": {
+        "Peerless-Midwest, Inc.": "7118241"
+    },
+    "Peoplelink Staffing Solutions": {
+        "Peoplelink Staffing Solutions": "7118297"
+    },
+    "Performance Trust": {
+        "Performance Trust Capital Partners": "7126856"
+    },
+    "Performance Trust Capital Partners": {
+        "Performance Trust Capital Partners": "7126856"
+    },
+    "Pete for America": {
+        "Pete for America": "7681740"
+    },
+    "Pine Grove Township": {
+        "Pine Grove Township": "7681813"
+    },
+    "Pinnacle Hospital": {
+        "Pinnacle Hospital": "7681625"
+    },
+    "Pioneer Regional School": {
+        "Pioneer Regional School": "7118867"
+    },
+    "Place Homes, Inc": {
+        "Place Homes, Inc.": "7681710"
+    },
+    "Plymouth Foundry": {
+        "Plymouth Foundry": "7118445"
+    },
+    "Pokagon Band Gaming Commission": {
+        "Pokagon Band Gaming Commission": "7681814"
+    },
+    "Polygon Company": {
+        "Polygon Company": "7118734"
+    },
+    "Portage District Library": {
+        "Portage District Library": "7123538"
+    },
+    "PPS & V Asset Management Consultants, Inc": {
+        "PPS & V Asset Management Consultants, Inc": "7123570"
+    },
+    "Primerus": {
+        "Primerus": "7123638"
+    },
+    "Professional Code Inspection of MI Inc": {
+        "Professional Code Inspection of MI Inc": "7123642"
+    },
+    "Promotion Concepts, Inc": {
+        "Promotion Concepts, Inc.": "7123648"
+    },
+    "Provident Bank": {
+        "Provident Bank": "7161423"
+    },
+    "PSI Molded Plastics": {
+        "PSI Molded Plastics": "7118448"
+    },
+    "Public Media Network": {
+        "Public Media Network": "7681815"
+    },
+    "Quantum Health, Inc": {
+        "Quantum Health, Inc.": "7161463"
+    },
+    "Qubit Networks": {
+        "Qubit Networks": "7681574"
+    },
+    "Radiology, Inc": {
+        "Radiology, Inc.": "7681626"
+    },
+    "REAL Services, Inc": {
+        "REAL Services, Inc.": "7118746"
+    },
+    "Receive Revenue Recovery": {
+        "Receive Revenue Recovery": "7681603"
+    },
+    "Red Rabbit Automation": {
+        "Red Rabbit Automation": "7118421"
+    },
+    "Region IV Area Agency on Aging": {
+        "Region IV Area Agency on Aging": "7123814"
+    },
+    "Reliant Mechanical, Inc": {
+        "Reliant Mechanical, Inc.": "7681869"
+    },
+    "REMAX 100": {
+        "REMAX 100": "7681627"
+    },
+    "Republic Roller Corp": {
+        "Republic Roller Corp.": "7401682"
+    },
+    "Residential Opportunities, Inc": {
+        "Residential Opportunities, Inc": "7123847"
+    },
+    "RETA Pregnancy Clinic & Family Resources": {
+        "RETA Pregnancy Clinic & Family Resources": "7118749"
+    },
+    "REV Federal Credit Union": {
+        "REV Federal Credit Union": "7126950"
+    },
+    "Richland Township": {
+        "Richland Township": "7681834"
+    },
+    "Richwood Banking Company": {
+        "Richwood Banking Company": "1449166"
+    },
+    "Rieth-Riley": {
+        "Rieth-Riley Construction Co., Inc.": "7118410"
+    },
+    "RJG, Inc": {
+        "RJG, Inc.": "7681844"
+    },
+    "Road Commission of Kalamazoo County": {
+        "Road Commission of Kalamazoo County, MI": "7123894"
+    },
+    "Roe-Comm, Inc": {
+        "Roe-Comm, Inc.": "7123912"
+    },
+    "Rollie Williams Paint Spot": {
+        "Rollie Williams Paint Spot": "7665913"
+    },
+    "Ron Jackson Insurance Agency": {
+        "Ron Jackson Insurance Agency": "7681817"
+    },
+    "Round 2 LLC": {
+        "Round 2 LLC": "7681628"
+    },
+    "RTC Industries, Inc": {
+        "RTC Industries, Inc.": "1449097"
+    },
+    "Ryan Logistics, Inc": {
+        "Ryan Logistics, Inc.": "4483062"
+    },
+    "Saginaw Intermediate School District": {
+        "Saginaw Intermediate School District": "7123997"
+    },
+    "Saint Mary's College": {
+        "Saint Mary's College": "7118316"
+    },
+    "Sam Jackson Enterprises, Inc": {
+        "Sam Jackson Enterprises, Inc.": "7161443"
+    },
+    "Scarpone & Co, PC": {
+        "Scarpone & Co., P.C.": "7124056"
+    },
+    "School City of East Chicago": {
+        "School City of East Chicago, IN": "7118420"
+    },
+    "School City of Hammond": {
+        "School City of Hammond, IN": "7118242"
+    },
+    "School City of Mishawaka": {
+        "School City of Mishawaka, IN": "7118243"
+    },
+    "Schoolcraft Community Schools": {
+        "Schoolcraft Community Schools": "7124075"
+    },
+    "Schupan & Sons, Inc": {
+        "Schupan & Sons, Inc.": "7124095"
+    },
+    "Schurz Communications, Inc": {
+        "Schurz Communications, Inc.": "7118322"
+    },
+    "Scope Services": {
+        "Scope Services": "7118320"
+    },
+    "Scripps": {
+        "Scripps Digital, Inc.": "7161427"
+    },
+    "Second Impressions": {
+        "Second Impressions": "7124133"
+    },
+    "Select Products": {
+        "Select Products": "7124152"
+    },
+    "SEMMA Health, Inc": {
+        "SEMMA Health, Inc.": "7118438"
+    },
+    "Service Express": {
+        "Service Express": "7127346"
+    },
+    "ServIT, Inc": {
+        "ServIT, Inc.": "7118375"
+    },
+    "Seyfarth Shaw LLP": {
+        "Seyfarth Shaw LLP": "7118344"
+    },
+    "Shah Properties": {
+        "Shah Properties LLC": "7161431"
+    },
+    "Shorr Packaging": {
+        "Shorr Packaging Corp.": "7681837"
+    },
+    "Silver Star Apartments": {
+        "Silver Star Apartments": "7124245"
+    },
+    "SIR Home Improvements": {
+        "SIR Home Improvements": "7681820"
+    },
+    "Site Enhancement Services": {
+        "Site Enhancement Services": "7681714"
+    },
+    "SLD Read": {
+        "SLD Read": "7681821"
+    },
+    "Smart Systems": {
+        "Smart Systems": "7118354"
+    },
+    "Smart Temps LLC": {
+        "Smart Temps LLC": "7681584"
+    },
+    "Smith Brothers": {
+        "Smith Brothers": "7118377"
+    },
+    "Solid Platforms, Inc": {
+        "Solid Platforms, Inc.": "7118376"
+    },
+    "South Bend Clinic": {
+        "South Bend Clinic": "7118766"
+    },
+    "South Bend Country Club": {
+        "South Bend Country Club": "7681629"
+    },
+    "South Bend Cubs": {
+        "South Bend Cubs": "7681586"
+    },
+    "South Bend Orthopaedics": {
+        "South Bend Orthopaedics": "7118430"
+    },
+    "South Bend Symphony Orchestra": {
+        "South Bend Symphony Orchestra": "7681570"
+    },
+    "Southwest Michigan Behavioral Health": {
+        "Southwest Michigan Behavioral Health": "7124423"
+    },
+    "Southwest Michigan Building Authority": {
+        "Southwest Michigan Building Authority": "7124429"
+    },
+    "Southwest Michigan First": {
+        "Southwest Michigan First": "7124436"
+    },
+    "Southwest Michigan Planning Commission": {
+        "Southwest Michigan Planning Commission": "7124443"
+    },
+    "Specialized Staffing Solutions": {
+        "Specialized Staffing Solutions": "7118284"
+    },
+    "Stanz": {
+        "Stanz Foodservice, Inc.": "7124754"
+    },
+    "STAR Financial Bank": {
+        "STAR Financial Bank": "7161394"
+    },
+    "StarCare Specialty Health System": {
+        "TxAce (StarCare Specialty Health Systems)": "7125609"
+    },
+    "Starin": {
+        "Starin": "7118413"
+    },
+    "Steel Cities Steels, Inc": {
+        "Steel Cities Steels, Inc": "7161497"
+    },
+    "Straight Line Data Networks": {
+        "Straight Line Data Networks": "7681717"
+    },
+    "Streamline HealthCare Solutions LLC": {
+        "Streamline Healthcare Solutions LLC": "7681823"
+    },
+    "StresCore, Inc": {
+        "StresCore, Inc.": "7118317"
+    },
+    "Studebaker Lofts": {
+        "Studebaker Lofts": "7118783"
+    },
+    "Studebaker National Museum": {
+        "Studebaker National Museum": "7681718"
+    },
+    "Supply Chain Solutions, Inc": {
+        "Supply Chain Solutions, Inc.": "7124967"
+    },
+    "Tecumseh Public Schools": {
+        "Tecumseh Public Schools": "7125038"
+    },
+    "TenPoint Complete": {
+        "TenPoint Complete": "4322099"
+    },
+    "Texas Township": {
+        "Texas Township": "7681826"
+    },
+    "The Architectural Group, Inc": {
+        "The Architectural Group, Inc.": "7125102"
+    },
+    "The Forest Condos": {
+        "The Forest Condos": "7118798"
+    },
+    "The History Museum": {
+        "The History Museum": "7118412"
+    },
+    "The Horton Group": {
+        "The Horton Group": "7118799"
+    },
+    "The Jordan Family Enterprise": {
+        "The Jordan Family Enterprise LLC": "7118302"
+    },
+    "The Law Office of Anthony W. Greco": {
+        "The Law Office of Anthony W. Greco": "3785285"
+    },
+    "The Lebermuth Company, Inc": {
+        "The Lebermuth Company, Inc.": "7118369"
+    },
+    "The Rogers Agency": {
+        "The Rogers Agency": "4699436"
+    },
+    "Thornapple Kellogg Schools": {
+        "Thornapple Kellogg Schools": "7125259"
+    },
+    "Thornapple Township": {
+        "Thornapple Township": "7681827"
+    },
+    "Thurston Woods Village, Inc": {
+        "Thurston Woods Village, Inc": "7125307"
+    },
+    "Tire Rack": {
+        "Tire Rack": "7118414"
+    },
+    "Tire Wholesalers Company, Inc": {
+        "Tire Wholesalers Company, Inc.": "7125327"
+    },
+    "Titan Sales and Consulting": {
+        "Titan Sales and Consulting": "7118347"
+    },
+    "TMJ & Sleep Therapy Centre": {
+        "TMJ & Sleep Therapy Centre": "7681722"
+    },
+    "TOPP Industries, Inc": {
+        "TOPP Industries, Inc.": "7681723"
+    },
+    "Transpo": {
+        "Transpo": "7118809"
+    },
+    "Tri-County Regional Jail": {
+        "Tri-County Regional Jail": "7161467"
+    },
+    "TriStar Molding, Inc": {
+        "TriStar Molding, Inc.": "7125563"
+    },
+    "True Inspection Services": {
+        "True Inspection Services": "2284392"
+    },
+    "TruPay Corporation": {
+        "TruPay Corporation": "7118249"
+    },
+    "Turbo Tires": {
+        "Turbo Tires": "7696365"
+    },
+    "TxAce (StarCare Specialty Health Systems)": {
+        "TxAce (StarCare Specialty Health Systems)": "7125609"
+    },
+    "UCO Industries": {
+        "UCO Industries": "1449070"
+    },
+    "Union Rural Electric Coop": {
+        "Union Rural Electric Coop": "1449079"
+    },
+    "Union Station Technology Center": {
+        "Union Station Technology Center": "7118265"
+    },
+    "United Federal Credit Union": {
+        "United Federal Credit Union": "7125708"
+    },
+    "Unity Physicians Hospital": {
+        "Unity Physicians Hospital": "7118820"
+    },
+    "Universal Bearings": {
+        "Universal Bearings, LLC": "7118291"
+    },
+    "Universal Home Health Care and Hospice": {
+        "Universal Home Health Care and Hospice": "7161469"
+    },
+    "Universal Property & Casualty Insurance": {
+        "Universal Property & Casualty Insurance": "7118821"
+    },
+    "University of Notre Dame": {
+        "University of Notre Dame": "7118372"
+    },
+    "US Signal": {
+        "US Signal Company, LLC": "7370304"
+    },
+    "US1": {
+        "US1 Industries": "7681838"
+    },
+    "USES Group": {
+        "USES Group": "7681593"
+    },
+    "Vail Rubber Works, Inc": {
+        "Vail Rubber Works, Inc.": "7677774"
+    },
+    "Valbruna Stainless, Inc": {
+        "Valbruna Stainless, Inc.": "7118319"
+    },
+    "Valley Screen Process Co, Inc": {
+        "Valley Screen Process Co., Inc.": "7681608"
+    },
+    "Van Buren & Cass District Health Dept": {
+        "Van Buren & Cass District Health Dept.": "7125793"
+    },
+    "Van Buren Community Mental Health": {
+        "Van Buren Community Mental Health": "7125817"
+    },
+    "Van Buren Intermediate School District": {
+        "Van Buren Intermediate School District": "7125837"
+    },
+    "VanDam & Krusinga Builders": {
+        "VanDam & Krusinga Builders": "7125848"
+    },
+    "Vanguard Eldercare Medical Group": {
+        "Vanguard Eldercare Medical Group": "7681609"
+    },
+    "Vedder": {
+        "Vedder Price, P.C.": "7118431"
+    },
+    "Venanpri Group LLC": {
+        "Venanpri Group LLC": "7127339"
+    },
+    "Vennli": {
+        "Vennli": "7681728"
+    },
+    "Vicksburg Community Schools": {
+        "Vicksburg Community Schools": "7125907"
+    },
+    "Visiting Angels of Southwest Michigan": {
+        "Visiting Angels of Southwest Michigan": "7125944"
+    },
+    "Vista Manufacturing": {
+        "Vista Manufacturing": "7118390"
+    },
+    "VMS Biomarketing": {
+        "VMS Biomarketing": "7118870"
+    },
+    "Vortex Tool Company": {
+        "Vortex Tool Company": "7681830"
+    },
+    "Walker Consultants": {
+        "Walker Consultants": "7126059"
+    },
+    "Walters-Dimmick Petroleum": {
+        "Walters-Dimmick Petroleum": "7126064"
+    },
+    "Watervliet Public Schools": {
+        "Watervliet Public Schools": "7126108"
+    },
+    "Weber Specialties": {
+        "Weber Specialties": "7126170"
+    },
+    "Weigand Construction Co, Inc": {
+        "Weigand Construction Co., Inc.": "7118828"
+    },
+    "Welch Packaging Group": {
+        "Welch Packaging Group": "7118280"
+    },
+    "Western Diversified Plastics": {
+        "Western Diversified Plastics": "7126247"
+    },
+    "Western Land Services, Inc": {
+        "Western Land Services, Inc": "7126257"
+    },
+    "Whirlpool Corporation": {
+        "Whirlpool Corporation": "7126318"
+    },
+    "White Cloud Public Schools": {
+        "White Cloud Public Schools": "7126325"
+    },
+    "Whiteford Kenworth": {
+        "Whiteford Kenworth": "7118379"
+    },
+    "Willard Public Library": {
+        "Willard Public Library": "7681832"
+    },
+    "Williams Aerial & Mapping, Inc": {
+        "Williams Aerial & Mapping, Inc.": "7118832"
+    },
+    "Windstream": {
+        "Windstream": "7370306"
+    },
+    "WMU Kalamazoo Autism Center": {
+        "WMU Kalamazoo Autism Center": "7126470"
+    },
+    "Wolverine Mutual": {
+        "Wolverine Mutual Insurance Co.": "7118411"
+    },
+    "Wood Temporary Staffing": {
+        "Wood Temporary Staffing": "7126510"
+    },
+    "Woodlands Behavioral Healthcare": {
+        "Woodlands Behavioral Healthcare": "7126520"
+    },
+    "Xanatek": {
+        "Xanatek": "7681730"
+    },
+    "Ziker Cleaners": {
+        "Ziker Cleaners": "7681731"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ It located in the NOC Playbook under "Tools and Shortcuts" -> "PS - Find Custome
 
 #### UI Elements for Selection Screen
 - **Client List**: Displays a scrollable list of all clients.
-- **Open OneNote Button**: Opens the OneNote of the currently highlighted client.
-- **Open Network & Wireless Button**: Opens the Network & Wireless folder of the currently highlighted client.
+- **Open OneNote Button**: Opens the OneNote documentation for the currently selected client.
+- **Open IT Glue Button**: Opens the IT Glue documentation for the currently selected client.
+- **Open Network & Wireless Button**: Opens the Network & Wireless folder of the currently selected client.
 - **Back Button**: Opens the main menu.
 
 #### Keyboard Shortcuts for Selection Screen
-- **Enter**: Opens the OneNote of the currently highlighted client.
-- **Control+Enter**: Opens the Network & Wireless folder of the currently highlighted client.
+- **Enter**: Opens the OneNote documentation for the currently selected client.
+- **Alt+Enter**: Opens the IT Glue documentation for the currently selected client.
+- **Control+Enter**: Opens the Network & Wireless folder of the currently selected client.
 - **Up/Down Arrows, Scroll Wheel**: Navigates through the list of clients.
 - **Tab, Right Click**: Toggles between favoriting and unfavoriting the currently highlighted client.
 - **Escape**: Opens the main menu.

--- a/compile_command.bat
+++ b/compile_command.bat
@@ -1,3 +1,3 @@
 python -m PyInstaller -F -i "icon.ico" --name="Find Client OneNote" "%~dp0Find Client OneNote.pyw" --onedir
 
-copy "icon.ico" "dist\Find Client OneNote\" & copy "transparent.ico" "dist\Find Client OneNote\"
+copy "icon.ico" "dist\Find Client OneNote\" & copy "transparent.ico" "dist\Find Client OneNote\" & copy "IT Glue Client IDs.json" "dist\Find Client OneNote\"


### PR DESCRIPTION
- Added new hardcoded "IT Glue Client IDs_JAN2024.json" file that holds client ids needed to retrieve IT Glue documentation. The goal is to eventually have this integrated within the main application, but currently the list needs to be generated separately (i.e. the application currently can't add new clients or remove olds ones)
- Added a new shortcut and GUI button that can be used to open a client's IT Glue documentation
- Updated the README.md to align with these changes